### PR TITLE
* NotificationWindows - Bugfix: TWinControl descendants are sometimes…

### DIFF
--- a/Examples/NotificationWindows/MyNotificationWindow.dfm
+++ b/Examples/NotificationWindows/MyNotificationWindow.dfm
@@ -1,26 +1,48 @@
 inherited MyNotificationWindow: TMyNotificationWindow
   Caption = 'My custom derived notification window'
+  ClientHeight = 119
   GlassFrame.Top = 0
+  ExplicitHeight = 143
   PixelsPerInch = 96
   TextHeight = 13
-  object Label1: TLabel
-    Left = 0
-    Top = 0
-    Width = 350
-    Height = 66
+  object MainLabel: TLabel
+    AlignWithMargins = True
+    Left = 3
+    Top = 3
+    Width = 344
+    Height = 81
+    Margins.Bottom = 35
     Align = alClient
     Alignment = taCenter
-    Caption = 'Add some text here to notify your users.'
+    Caption = 'Here comes the important message...'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
     Font.Height = -13
     Font.Name = 'Tahoma'
     Font.Style = []
-    GlowSize = 2
     ParentFont = False
     ShowAccelChar = False
     Layout = tlCenter
-    ExplicitWidth = 234
-    ExplicitHeight = 20
+    ExplicitLeft = 0
+    ExplicitTop = 0
+    ExplicitWidth = 216
+    ExplicitHeight = 16
+  end
+  object MainActionButton: TButton
+    Left = 216
+    Top = 86
+    Width = 126
+    Height = 25
+    Caption = 'Action!'
+    TabOrder = 0
+    OnClick = MainActionButtonClick
+  end
+  object ProgressBar: TProgressBar
+    Left = 8
+    Top = 90
+    Width = 202
+    Height = 17
+    TabOrder = 1
+    Visible = False
   end
 end

--- a/Examples/NotificationWindows/MyNotificationWindow.pas
+++ b/Examples/NotificationWindows/MyNotificationWindow.pas
@@ -3,17 +3,73 @@ unit MyNotificationWindow;
 interface
 
 uses
-  Windows, Messages, SysUtils, Variants, Classes, Graphics, Controls, Forms,
-  Dialogs, StdCtrls, NotificationWindows, AnyiQuack;
+  Winapi.Windows,
+  Winapi.Messages,
+  System.SysUtils,
+  System.Variants,
+  System.Classes,
+  Vcl.Graphics,
+  Vcl.Controls,
+  Vcl.Forms,
+  Vcl.Dialogs,
+  Vcl.StdCtrls,
+  Vcl.ComCtrls,
+
+  NotificationWindows,
+  AnyiQuack;
 
 type
   TMyNotificationWindow = class(TNotificationWindow)
-    Label1:TLabel;
+    MainLabel: TLabel;
+    MainActionButton: TButton;
+    ProgressBar: TProgressBar;
+    procedure MainActionButtonClick(Sender: TObject);
+
+  protected
+    function AutoClosePossible: Boolean; override;
   end;
 
 implementation
 
 {$R *.dfm}
 
+function TMyNotificationWindow.AutoClosePossible: Boolean;
+begin
+  if ProgressBar.Visible and (ProgressBar.Position < ProgressBar.Max) then
+    Result := False
+  else
+    Result := inherited AutoClosePossible;
+end;
+
+procedure TMyNotificationWindow.MainActionButtonClick(Sender: TObject);
+begin
+  MainActionButton.Enabled := False;
+  ProgressBar.Visible := True;
+
+  Take(ProgressBar)
+    .EachInterval(60,
+      function(AQ: TAQ; O: TObject): Boolean
+      var
+        PB: TProgressBar absolute O;
+      begin
+        if PB.Position < PB.Max then
+          PB.Position := PB.Position + 1
+        else
+        begin
+          AQ.CancelIntervals;
+          MainLabel.Caption := 'Done!';
+
+          Take(Self)
+            .EachDelay(1000,
+              function(AQ: TAQ; O: TObject): Boolean
+              begin
+                Close;
+                Result := True;
+              end);
+        end;
+        Result := True;
+      end);
+
+end;
 
 end.

--- a/Examples/NotificationWindows/NotificationExample.dproj
+++ b/Examples/NotificationWindows/NotificationExample.dproj
@@ -62,7 +62,7 @@
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Locale>1033</VerInfo_Locale>
-        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
         <Icon_MainIcon>NotificationExample_Icon.ico</Icon_MainIcon>
         <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
         <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>

--- a/NotificationWindowsFramework/NotificationWindows.pas
+++ b/NotificationWindowsFramework/NotificationWindows.pas
@@ -3,8 +3,21 @@ unit NotificationWindows;
 interface
 
 uses
-  Windows, Messages, SysUtils, Contnrs, Variants, Classes, Graphics, Controls, Forms,
-  Dialogs, Generics.Collections, Math, AnyiQuack, AQPControlAnimations;
+  Winapi.Windows,
+  Winapi.Messages,
+  System.SysUtils,
+  System.Contnrs,
+  System.Variants,
+  System.Classes,
+  System.Math,
+  Vcl.Graphics,
+  Vcl.Controls,
+  Vcl.Forms,
+  Vcl.Dialogs,
+  Generics.Collections,
+
+  AnyiQuack,
+  AQPControlAnimations;
 
 type
   TNotificationStack = class;
@@ -201,7 +214,19 @@ begin
           IfThen(WindowIndex = 0, InPositionAnimationDuration div 2, InPositionAnimationDuration),
           PositionAnimationID, TAQ.Ease(etBack, emInInverted));
         AniPlugin.AlphaBlendAnimation(MAXBYTE, InAlphaAnimationDuration,
-          AlphaAnimationID, TAQ.Ease(etSinus));
+          AlphaAnimationID, TAQ.Ease(etSinus),
+          procedure(Sender: TObject)
+          var
+            NWindow: TNotificationWindow absolute Sender;
+          begin
+            // Win 10 bugfix: TWinControl descendants are sometimes not rendered, but
+            // the switch AlphaBlend off and on again solve the issue.
+            if Assigned(Sender) and (Sender is TNotificationWindow) then
+            begin
+              NWindow.AlphaBlend := False;
+              NWindow.AlphaBlend := True;
+            end;
+          end);
 
         Inc(WindowIndex);
         Result := True;


### PR DESCRIPTION
… not rendered on Win 10, but the switch AlphaBlend off and on again solve the issue.

* Notification example extended
* Compiled Notification example updated in the ZIP file